### PR TITLE
Add scripts for running clang-format and cppcheck

### DIFF
--- a/tools/check_code.sh
+++ b/tools/check_code.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+
+cppcheck -q --force --enable=all --inconclusive --suppress=missingIncludeSystem -I ./include ./

--- a/tools/check_style.sh
+++ b/tools/check_style.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env sh
+
+FILES=$(find ./ -iname *.h -o -iname *.c -o -iname *.cc -o -iname *.hpp -o -iname *.cpp)
+
+if [ "$1" = "--fix" ]
+then
+  for FILE in $FILES; do clang-format-3.6 -style=file -i $FILE; done
+else
+  for FILE in $FILES; do clang-format-3.6 -style=file $FILE | diff $FILE -; done
+fi


### PR DESCRIPTION
* Add script for running clang-format-3.6 among all project source files (`*.h`, `*.c`, `*.cc`, `*.hpp`, `*.cpp`)
* Add script for running cppcheck among all project source files