### PR TITLE
Add googletest submodule

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -7,7 +7,7 @@ AllowShortFunctionsOnASingleLine: Empty
 AllowShortIfStatementsOnASingleLine: false
 AllowShortLoopsOnASingleLine: false
 BinPackArguments: true
-BinPackParameters: false
+BinPackParameters: true
 BreakConstructorInitializersBeforeComma: true
 DerivePointerAlignment: false
 PointerAlignment: Left

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "test/googletest"]
+	path = test/googletest
+	url = https://github.com/google/googletest.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ addons:
     - ubuntu-toolchain-r-test
     - llvm-toolchain-precise-3.6
     packages:
-    - gcc-4.8
-    - g++-4.8
+    - gcc-5
+    - g++-5
     - clang-format-3.6
     - cppcheck
 
@@ -21,7 +21,7 @@ compiler:
   - gcc
 
 install:
-  - if [ "$CXX" = "g++" ]; then export CXX="g++-4.8" CC="gcc-4.8"; fi
+  - if [ "$CXX" = "g++" ]; then export CXX="g++-5" CC="gcc-5"; fi
 
 script:
   - bash -e ./tools/check_style.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,3 +30,4 @@ script:
   - cd build
   - cmake ../
   - make
+  - make test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,32 @@
+# Copyright (c) 2017 Artem Nosach
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+cmake_minimum_required(VERSION 2.8.7)
+
+project(october)
+
+set(GCC_COVERAGE_COMPILE_FLAGS "-O2 -Wextra -Werror -std=c++14")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${GCC_COVERAGE_COMPILE_FLAGS}")
+
+include_directories(include)
+
+enable_testing()
+
+add_subdirectory(test)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,26 @@
+# Copyright (c) 2017 Artem Nosach
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+include_directories(
+  googletest/googletest/include
+  googletest/googlemock/include
+)
+
+add_subdirectory(googletest)

--- a/tools/check_code.sh
+++ b/tools/check_code.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env sh
 
-cppcheck -q --force --enable=all --inconclusive --suppress=missingIncludeSystem -I ./include ./
+cppcheck -q --force --enable=all --inconclusive --suppress=missingIncludeSystem -I ./include ./ -i ./test

--- a/tools/check_style.sh
+++ b/tools/check_style.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 
-FILES=$(find ./ -iname *.h -o -iname *.c -o -iname *.cc -o -iname *.hpp -o -iname *.cpp)
+FILES=$(find ./ -type d -name googletest -prune -iname *.h -o -iname *.c -o -iname *.cc -o -iname *.hpp -o -iname *.cpp)
 
 if [ "$1" = "--fix" ]
 then


### PR DESCRIPTION
* Add `googletest` library as project submodule
* Exclude `googletest` folder from `clang-format` paths
* Exclude whole `test` folder from `cppcheck` paths
* Increase gcc version to 5 for c++14 features support