### PR TITLE
Extend node functionality

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,33 +1,23 @@
-sudo: false
+os: linux
 
 language: cpp
-
-cache:
-  apt: true
+compiler: gcc
 
 addons:
   apt:
     sources:
-    - ubuntu-toolchain-r-test
-    - llvm-toolchain-precise-3.6
+      - ubuntu-toolchain-r-test
     packages:
-    - gcc-5
-    - g++-5
-    - clang-format-3.6
-    - cppcheck
+      - g++-7
+      - cppcheck
 
-compiler:
-  - clang
-  - gcc
-
-install:
-  - if [ "$CXX" = "g++" ]; then export CXX="g++-5" CC="gcc-5"; fi
+before_script:
+  - export CC=gcc-7
+  - export CXX=g++-7
 
 script:
   - bash -e ./tools/check_style.sh
   - bash -e ./tools/check_code.sh
   - mkdir build
   - cd build
-  - cmake ../
-  - make
-  - make test
+  - cmake ../ && make && make test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ cmake_minimum_required(VERSION 2.8.7)
 
 project(october)
 
-set(GCC_COVERAGE_COMPILE_FLAGS "-O2 -Wextra -Werror -std=c++14")
+set(GCC_COVERAGE_COMPILE_FLAGS "-fno-exceptions -O2 -Wall -Wextra -Werror -std=c++17")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${GCC_COVERAGE_COMPILE_FLAGS}")
 
 include_directories(include)

--- a/include/geometry.h
+++ b/include/geometry.h
@@ -22,9 +22,9 @@
 
 #pragma once
 
+#include <algorithm>
 #include <cmath>
 #include <limits>
-#include <algorithm>
 
 namespace october {
 namespace geometry {

--- a/include/node.h
+++ b/include/node.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 Artem Nosach
+ * Copyright (c) 2018 Artem Nosach
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -22,69 +22,140 @@
 
 #pragma once
 
-#include <cstddef>
-#include <array>
-#include <memory>
 #include <utility>
+#include <functional>
 #include <algorithm>
+#include <tuple>
 
 namespace october {
 namespace node {
 
 /**
- * @brief Represents type of pointer to node
+ * @brief Represents node with custom payload and childs container
  */
-template <typename NodeType>
-using NodePointer = std::unique_ptr<NodeType>;
-
-/**
- * @brief Represents tree node with custom payload and arbitrary childs count
- */
-template <typename PayloadType, std::size_t N>
+template <typename Payload, typename ChildsContainer>
 class Node {
  public:
   /**
-   * @brief Type of container for pointers to child nodes
-   */
-  using ChildNodesContainerType = std::array<NodePointer<Node>, N>;
-
-  /**
    * @brief Constructor
    * @param payload Payload to be stored in the node
-   * @param childs STL container of pointers to child nodes (takes ownership)
+   * @param childs STL container of pointers to child nodes
    */
   template <typename U, typename V>
-  Node(U&& payload, V&& childs)
+  explicit Node(U&& payload, V&& childs)
       : payload_(std::forward<U>(payload)), childs_(std::forward<V>(childs)) {}
 
   /**
-   * @brief Processes node recursively with given user function.
+   * @brief Processes node's payload recursively with given user function.
    * Uses DFS pre-order algorithm with selective child nodes processing
    * (user function returns scope of child nodes to be processed on next step)
    *
-   * @param function Function to be applied to nodes recursively.
+   * @param process_func Function to be applied to nodes recursively.
    * Function is expected to have following signature:
-   * "Container function(PayloadType&, ...)"
+   * "Container function(Payload&, ...)"
    * where "Container" type is STL container of child nodes indexes
+   *
+   * @param interpolate_func Function to be applied to arguments list
+   * before each child processing for modifying arguments according to
+   * child's index (arguments interpolation).
+   * Function is expected to have following signature:
+   * "std::tuple<Args...> function(Args...)"
+   * where returned tuple will be unpacked and passed to child's
+   * processPayload()
    *
    * @param args Various arguments list to be passed to user function
    */
-  template <typename F, typename... Args>
-  void process(const F& function, Args&&... args) {
-    const auto& target_childs = function(payload_, std::forward<Args>(args)...);
+  template <typename ProcessFunc, typename InterpolateFunc, typename... Args>
+  void processPayload(const ProcessFunc& process_func,
+                      const InterpolateFunc& interpolate_func, Args&&... args) {
+    const auto& target_childs = std::invoke(process_func, payload_, args...);
     std::for_each(
         target_childs.begin(), target_childs.end(),
         [&](const auto& child_index) {
           if (child_index < childs_.size() && childs_.at(child_index)) {
-            childs_.at(child_index)
-                ->process(function, std::forward<Args>(args)...);
+            processChildNodePayload(
+                childs_.at(child_index), process_func, interpolate_func,
+                std::tuple(std::invoke(interpolate_func, child_index, args...)),
+                std::make_index_sequence<sizeof...(Args)>{});
+          }
+        });
+  }
+
+  /**
+   * @brief Processes node's childs recursively with given user function.
+   * Uses DFS pre-order algorithm with selective child nodes processing
+   * (user function returns scope of child nodes to be processed on next step)
+   *
+   * @param process_func Function to be applied to nodes recursively.
+   * Function is expected to have following signature:
+   * "Container function(ChildsContainer&, ...)"
+   * where "Container" type is STL container of child nodes indexes
+   *
+   * @param interpolate_func Function to be applied to arguments list
+   * before each child processing for modifying arguments according to
+   * child's index (arguments interpolation).
+   * Function is expected to have following signature:
+   * "std::tuple<Args...> function(Args...)"
+   * where returned tuple will be unpacked and passed to child's
+   * processChilds()
+   *
+   * @param args Various arguments list to be passed to user function
+   */
+  template <typename ProcessFunc, typename InterpolateFunc, typename... Args>
+  void processChilds(const ProcessFunc& process_func,
+                     const InterpolateFunc& interpolate_func, Args&&... args) {
+    const auto& target_childs = std::invoke(process_func, childs_, args...);
+    std::for_each(
+        target_childs.begin(), target_childs.end(),
+        [&](const auto& child_index) {
+          if (child_index < childs_.size() && childs_.at(child_index)) {
+            processChildNodeChilds(
+                childs_.at(child_index), process_func, interpolate_func,
+                std::tuple(std::invoke(interpolate_func, child_index, args...)),
+                std::make_index_sequence<sizeof...(Args)>{});
           }
         });
   }
 
  private:
-  PayloadType payload_;
-  ChildNodesContainerType childs_;
+  /**
+   * @brief Invokes processPayload() method for certain child node
+   * @param child_node Child node for which function call will be performed
+   * @param process_func Process function to be passed to function call
+   * @param interpolate_func Interpolate function to be passed to function call
+   * @param tuple Tuple of arguments to be unpacked and passed to function call
+   */
+  template <typename ChildNode, typename ProcessFunc, typename InterpolateFunc,
+            typename Tuple, auto... I>
+  static void processChildNodePayload(const ChildNode& child_node,
+                                      const ProcessFunc& process_func,
+                                      const InterpolateFunc& interpolate_func,
+                                      Tuple&& tuple,
+                                      std::index_sequence<I...>) {
+    child_node->processPayload(process_func, interpolate_func,
+                               std::get<I>(std::forward<Tuple>(tuple))...);
+  }
+
+  /**
+   * @brief Invokes processChilds() method for certain child node
+   * @param child_node Child node for which function call will be performed
+   * @param process_func Process function to be passed to function call
+   * @param interpolate_func Interpolate function to be passed to function call
+   * @param tuple Tuple of arguments to be unpacked and passed to function call
+   */
+  template <typename ChildNode, typename ProcessFunc, typename InterpolateFunc,
+            typename Tuple, auto... I>
+  static void processChildNodeChilds(const ChildNode& child_node,
+                                     const ProcessFunc& process_func,
+                                     const InterpolateFunc& interpolate_func,
+                                     Tuple&& tuple, std::index_sequence<I...>) {
+    child_node->processChilds(process_func, interpolate_func,
+                              std::get<I>(std::forward<Tuple>(tuple))...);
+  }
+
+ private:
+  Payload payload_;
+  ChildsContainer childs_;
 };
 
 }  // namespace node

--- a/include/node.h
+++ b/include/node.h
@@ -22,10 +22,10 @@
 
 #pragma once
 
-#include <utility>
-#include <functional>
 #include <algorithm>
+#include <functional>
 #include <tuple>
+#include <utility>
 
 namespace october {
 namespace node {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -20,6 +20,7 @@
 
 include_directories(
   googletest/googletest/include
+  googletest/googlemock/include
 )
 
 set(GEOMETRY_SOURCES
@@ -33,6 +34,8 @@ set(NODE_SOURCES
 set(LIBRARIES
   gtest
   gtest_main
+  gmock
+  gmock_main
   pthread
 )
 

--- a/test/src/node_test.cc
+++ b/test/src/node_test.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 Artem Nosach
+ * Copyright (c) 2018 Artem Nosach
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -22,9 +22,13 @@
 
 #include <cstddef>
 #include <vector>
-#include <utility>
+#include <functional>
+#include <array>
+#include <memory>
 #include <algorithm>
+#include <utility>
 
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 #include "node.h"
@@ -33,130 +37,188 @@ namespace october {
 namespace node {
 namespace test {
 
-using ChildNodesTestData = std::vector<std::size_t>;
+using ChildsIndexesData = std::vector<std::size_t>;
 
-const std::vector<ChildNodesTestData> fillChildNodesData(
-    const std::size_t range) {
-  std::vector<ChildNodesTestData> result;
-  for (std::size_t i = 0u; i < range; ++i) {
-    for (std::size_t j = 0u; j < range; ++j) {
-      for (std::size_t k = 0u; k < range; ++k) {
-        for (std::size_t l = 0u; l < range; ++l) {
-          result.push_back({i, j, k, l});
-        }
-      }
-    }
-  }
-  return result;
-}
-
-static const std::vector<ChildNodesTestData> child_nodes_data =
-    fillChildNodesData(2u);
-static const std::vector<ChildNodesTestData> child_nodes_to_process_data =
-    fillChildNodesData(4u);
-
-template <std::size_t N>
-struct TypeValue {
-  static const std::size_t value_ = N;
+// clang-format off
+static const std::vector<ChildsIndexesData> childs_indexes_data = {
+  {},
+  {0u},
+  {0u, 1u},
+  {0u, 1u, 1u},
+  {1u, 0u, 0u, 1u},
+  {1u, 1u, 0u, 0u, 0u},
+  {0u, 1u, 1u, 0u, 1u, 1u},
+  {1u, 0u, 1u, 0u, 1u, 0u, 1u},
+  {1u, 1u, 1u, 1u, 1u, 1u, 1u, 1u},
 };
 
-struct PayloadTestData {
-  PayloadTestData() : value_(0u) {}
-  explicit PayloadTestData(const std::size_t value) : value_(value) {}
+static const std::vector<ChildsIndexesData> childs_to_process_indexes_data = {
+  {},
+  {0u},
+  {0u, 1u},
+  {0u, 1u, 2u},
+  {0u, 1u, 2u, 3u},
+  {0u, 1u, 2u, 3u, 4u},
+  {0u, 1u, 2u, 3u, 4u, 5u},
+  {0u, 1u, 2u, 3u, 4u, 5u, 6u},
+  {0u, 1u, 2u, 3u, 4u, 5u, 6u, 7u}
+};
+// clang-format on
 
-  std::size_t value_;
+class NodeMock;
+
+using PayloadTestData = float;
+using ChildsTestData = std::array<std::unique_ptr<NodeMock>, 8u>;
+using ParameterTestData = float;
+
+using ProcessPayloadFunc = std::function<ChildsIndexesData(
+    const PayloadTestData&, ParameterTestData, const ParameterTestData&)>;
+using ProcessChildsFunc = std::function<ChildsIndexesData(
+    const ChildsTestData&, ParameterTestData, const ParameterTestData&)>;
+using InterpolateFunc =
+    std::function<std::tuple<ParameterTestData, const ParameterTestData&>(
+        std::size_t, ParameterTestData, const ParameterTestData&)>;
+
+class FunctionMock {
+ public:
+  MOCK_CONST_METHOD3(processPayloadFunc,
+                     ChildsIndexesData(const PayloadTestData&,
+                                       ParameterTestData,
+                                       const ParameterTestData&));
+  MOCK_CONST_METHOD3(processChildsFunc,
+                     ChildsIndexesData(const ChildsTestData&, ParameterTestData,
+                                       const ParameterTestData&));
+  MOCK_CONST_METHOD3(interpolateFunc,
+                     std::tuple<ParameterTestData, const ParameterTestData&>(
+                         std::size_t, ParameterTestData,
+                         const ParameterTestData&));
 };
 
-ChildNodesTestData writeFunc(PayloadTestData& origin,
-                             const PayloadTestData& input,
-                             const ChildNodesTestData& result) {
-  origin = input;
-  return result;
-}
+class NodeMock {
+ public:
+  MOCK_CONST_METHOD4(processPayload,
+                     void(ProcessPayloadFunc, InterpolateFunc,
+                          ParameterTestData, const ParameterTestData&));
+  MOCK_CONST_METHOD4(processChilds,
+                     void(ProcessChildsFunc, InterpolateFunc, ParameterTestData,
+                          const ParameterTestData&));
+};
 
-ChildNodesTestData readFunc(const PayloadTestData& origin,
-                            PayloadTestData& output,
-                            const ChildNodesTestData& result) {
-  output = origin;
-  return result;
-}
-
-template <typename T>
-class NodeTest : public ::testing::Test {
+class NodeTest : public ::testing::TestWithParam<
+                     std::tuple<ChildsIndexesData, ChildsIndexesData> > {
  protected:
-  using NodeType = Node<PayloadTestData, T::value_>;
-  using ChildNodesContainerType = typename NodeType::ChildNodesContainerType;
+  void SetUp() {
+    using namespace std::placeholders;
 
-  void setNode(const ChildNodesTestData& child_nodes) {
-    ChildNodesContainerType childs;
-    for (std::size_t i = 0; i < child_nodes.size(); ++i) {
-      if (i < childs.size() && 0u != child_nodes.at(i)) {
-        childs[i].reset(
-            new NodeType(PayloadTestData(), ChildNodesContainerType()));
-      }
-    }
-    node_.reset(new NodeType(PayloadTestData(), std::move(childs)));
+    process_payload_func_ = std::bind(&FunctionMock::processPayloadFunc,
+                                      &function_mock_, _1, _2, _3);
+    process_childs_func_ = std::bind(&FunctionMock::processChildsFunc,
+                                     &function_mock_, _1, _2, _3);
+    interpolate_func_ =
+        std::bind(&FunctionMock::interpolateFunc, &function_mock_, _1, _2, _3);
   }
 
-  template <typename F, typename... Args>
-  void processNode(const F& function, Args&&... args) {
-    node_->process(function, std::forward<Args>(args)...);
-  }
-
- private:
-  NodePointer<NodeType> node_;
+ protected:
+  FunctionMock function_mock_;
+  ProcessPayloadFunc process_payload_func_;
+  ProcessChildsFunc process_childs_func_;
+  InterpolateFunc interpolate_func_;
 };
 
-typedef ::testing::Types<TypeValue<0u>, TypeValue<1u>, TypeValue<2u>,
-                         TypeValue<3u>, TypeValue<4u> > TestTypes;
+TEST_P(NodeTest, ProcessRootPayload_Success) {
+  using namespace ::testing;
 
-TYPED_TEST_CASE(NodeTest, TestTypes);
+  Node<PayloadTestData, ChildsTestData> node((PayloadTestData(0.0f)),
+                                             (ChildsTestData()));
 
-TYPED_TEST(NodeTest, ProcessRootNode_Success) {
-  const std::size_t payload_value = 8u;
-  PayloadTestData payload;
+  EXPECT_CALL(function_mock_, processPayloadFunc(0.0f, 1.0f, 2.0f));
+  EXPECT_CALL(function_mock_, processChildsFunc(_, _, _)).Times(0);
+  EXPECT_CALL(function_mock_, interpolateFunc(_, _, _)).Times(0);
 
-  for (const auto& child_nodes : child_nodes_data) {
-    this->setNode(child_nodes);
-    this->processNode(readFunc, payload, ChildNodesTestData());
-    EXPECT_NE(payload_value, payload.value_);
-
-    this->processNode(writeFunc, PayloadTestData(payload_value),
-                      ChildNodesTestData());
-    this->processNode(readFunc, payload, ChildNodesTestData());
-    EXPECT_EQ(payload_value, payload.value_);
-  }
+  node.processPayload(process_payload_func_, interpolate_func_, 1.0f, 2.0f);
 }
 
-TYPED_TEST(NodeTest, ProcessChildNodes_Success) {
-  const std::size_t payload_value = 8u;
-  PayloadTestData payload;
+TEST_P(NodeTest, ProcessRootChilds_Success) {
+  using namespace ::testing;
 
-  for (const auto& child_nodes : child_nodes_data) {
-    for (const auto& to_process : child_nodes_to_process_data) {
-      this->setNode(child_nodes);
-      for (std::size_t i = 0; i < child_nodes.size(); ++i) {
-        if (i < TypeParam::value_ && 0u != child_nodes.at(i)) {
-          this->processNode(readFunc, payload, ChildNodesTestData({i}));
-          EXPECT_NE(payload_value, payload.value_);
-        }
-      }
+  Node<PayloadTestData, ChildsTestData> node((PayloadTestData()),
+                                             (ChildsTestData()));
 
-      this->processNode(writeFunc, PayloadTestData(payload_value), to_process);
-      for (std::size_t i = 0; i < child_nodes.size(); ++i) {
-        if (i < TypeParam::value_ && 0u != child_nodes.at(i)) {
-          this->processNode(readFunc, payload, ChildNodesTestData({i}));
-          if (to_process.end() !=
-              std::find(to_process.begin(), to_process.end(), i)) {
-            EXPECT_EQ(payload_value, payload.value_);
-          } else {
-            EXPECT_NE(payload_value, payload.value_);
-          }
-        }
+  EXPECT_CALL(function_mock_, processChildsFunc(_, 1.0f, 2.0f));
+  EXPECT_CALL(function_mock_, processPayloadFunc(_, _, _)).Times(0);
+  EXPECT_CALL(function_mock_, interpolateFunc(_, _, _)).Times(0);
+
+  node.processChilds(process_childs_func_, interpolate_func_, 1.0f, 2.0f);
+}
+
+TEST_P(NodeTest, ProcessChildsPayload_Success) {
+  using namespace ::testing;
+
+  ChildsTestData childs;
+  ChildsIndexesData childs_indexes = std::get<0>(GetParam());
+  ChildsIndexesData childs_to_process_indexes = std::get<1>(GetParam());
+
+  for (std::size_t i = 0; i < childs_indexes.size(); ++i) {
+    if (0 != childs_indexes.at(i)) {
+      childs.at(i) = std::make_unique<NodeMock>();
+      if (childs_to_process_indexes.end() !=
+          std::find(childs_to_process_indexes.begin(),
+                    childs_to_process_indexes.end(), i)) {
+        EXPECT_CALL(*childs.at(i).get(), processPayload(_, _, 2.0f, 1.0f));
+      } else {
+        EXPECT_CALL(*childs.at(i).get(), processPayload(_, _, _, _)).Times(0);
       }
+      EXPECT_CALL(*childs.at(i).get(), processChilds(_, _, _, _)).Times(0);
     }
   }
+
+  Node<PayloadTestData, ChildsTestData> node((PayloadTestData()),
+                                             std::move(childs));
+
+  EXPECT_CALL(function_mock_, processPayloadFunc(_, _, _))
+      .WillOnce(Return(childs_to_process_indexes));
+  EXPECT_CALL(function_mock_, interpolateFunc(_, 1.0f, 2.0f))
+      .WillRepeatedly(Return(std::make_tuple(2.0f, 1.0f)));
+
+  node.processPayload(process_payload_func_, interpolate_func_, 1.0f, 2.0f);
 }
+
+TEST_P(NodeTest, ProcessChildsChilds_Success) {
+  using namespace ::testing;
+
+  ChildsTestData childs;
+  ChildsIndexesData childs_indexes = std::get<0>(GetParam());
+  ChildsIndexesData childs_to_process_indexes = std::get<1>(GetParam());
+
+  for (std::size_t i = 0; i < childs_indexes.size(); ++i) {
+    if (0 != childs_indexes.at(i)) {
+      childs.at(i) = std::make_unique<NodeMock>();
+      if (childs_to_process_indexes.end() !=
+          std::find(childs_to_process_indexes.begin(),
+                    childs_to_process_indexes.end(), i)) {
+        EXPECT_CALL(*childs.at(i).get(), processChilds(_, _, 2.0f, 1.0f));
+      } else {
+        EXPECT_CALL(*childs.at(i).get(), processChilds(_, _, _, _)).Times(0);
+      }
+      EXPECT_CALL(*childs.at(i).get(), processPayload(_, _, _, _)).Times(0);
+    }
+  }
+
+  Node<PayloadTestData, ChildsTestData> node((PayloadTestData()),
+                                             std::move(childs));
+
+  EXPECT_CALL(function_mock_, processChildsFunc(_, _, _))
+      .WillOnce(Return(childs_to_process_indexes));
+  EXPECT_CALL(function_mock_, interpolateFunc(_, 1.0f, 2.0f))
+      .WillRepeatedly(Return(std::make_tuple(2.0f, 1.0f)));
+
+  node.processChilds(process_childs_func_, interpolate_func_, 1.0f, 2.0f);
+}
+
+INSTANTIATE_TEST_CASE_P(
+    ChildsIndexesInstantiation, NodeTest,
+    ::testing::Combine(::testing::ValuesIn(childs_indexes_data),
+                       ::testing::ValuesIn(childs_to_process_indexes_data)));
 
 }  // namespace test
 }  // namespace node

--- a/test/src/node_test.cc
+++ b/test/src/node_test.cc
@@ -20,13 +20,13 @@
  * SOFTWARE.
  */
 
-#include <cstddef>
-#include <vector>
-#include <functional>
-#include <array>
-#include <memory>
 #include <algorithm>
+#include <array>
+#include <cstddef>
+#include <functional>
+#include <memory>
 #include <utility>
+#include <vector>
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"

--- a/tools/check_style.sh
+++ b/tools/check_style.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env sh
 
-FILES=$(find ./ -type d -name googletest -prune -o -iname *.h -o -iname *.c -o -iname *.cc -o -iname *.hpp -o -iname *.cpp -print)
+FILES=$(find ./ -iname build -prune -o -iname googletest -prune -o \( -iname *.h -o -iname *.c -o -iname *.cc -o -iname *.hpp -o -iname *.cpp \) -type f -print)
 
 if [ "$1" = "--fix" ]
 then
-  for FILE in $FILES; do clang-format-3.6 -style=file -i $FILE; done
+  for FILE in $FILES; do clang-format -style=file -i $FILE; done
 else
-  for FILE in $FILES; do clang-format-3.6 -style=file $FILE | diff $FILE -; done
+  for FILE in $FILES; do clang-format -style=file $FILE | diff $FILE -; done
 fi


### PR DESCRIPTION
1. Extend `Node` class with next functionality:
- Use template parameter `ChildsContainer` as childs container type (do not hardcode `std::array<std::unique_ptr<Node>, N>` as a container)
- Add `processChilds()` method for node's childs processing in the same way as payload
- Pass interpolate function with signature `std::tuple<Args...> func(child_index, Args...)` to `processPayload()` and `processChilds()` methods to allow parameters modifying for each child by index
2. Update unit tests to cover new `Node` functionality
3. Update compiler version and build flags for C++17 features support
4. Remove clang build from travis CI due to unsupporting clang-6.0