### PR TITLE
Add codecov support

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,7 @@
+ignore:
+  - test
+  - benchmark
+
+comment:
+  layout: header, changes, diff
+  behavior: default

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ before_script:
 script:
   - bash -e ./tools/check_style.sh
   - bash -e ./tools/check_code.sh
-  - mkdir build
-  - cd build
-  - cmake ../ && make && make test && make benchmark_run
+  - mkdir build && cd build
+  - cmake ../ && make
+  - make test
+  - bash <(curl -s https://codecov.io/bash) -X coveragepy
+  - make benchmark_run

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -18,6 +18,9 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+set(OCTOBER_TEST_COMPILE_FLAGS "--coverage")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OCTOBER_TEST_COMPILE_FLAGS}")
+
 include_directories(
   googletest/googletest/include
   googletest/googlemock/include

--- a/tools/collect_coverage.sh
+++ b/tools/collect_coverage.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env sh
+
+SRC_DIR=$1
+OBJECT_DIR=test/CMakeFiles
+COVERAGE_DIR=test/coverage
+
+find . -name *.gcda -type f -delete
+rm -rf $COVERAGE_DIR
+mkdir $COVERAGE_DIR
+
+make
+lcov --no-external --capture --initial --base-directory $SRC_DIR --directory $OBJECT_DIR --output-file $COVERAGE_DIR/lcov_initial.info
+
+make test
+lcov --no-external --capture --base-directory $SRC_DIR --directory $OBJECT_DIR --output-file $COVERAGE_DIR/lcov_processed.info
+lcov --add-tracefile $COVERAGE_DIR/lcov_initial.info --add-tracefile $COVERAGE_DIR/lcov_processed.info --output-file $COVERAGE_DIR/lcov_result.info
+
+genhtml $COVERAGE_DIR/lcov_result.info --output-directory=$COVERAGE_DIR/report


### PR DESCRIPTION
* Compile tests with `--coverage` flag to allow code coverage collecting
* Add `.codecov.yml` file with codecov settings
* Extend `.travis.yml` file to trigger code coverage calculating
* Provide `sh` script for local code coverage report preparing