### PR TITLE
Correct benchmark implementation

### DIFF
--- a/benchmark/src/node_benchmark.cc
+++ b/benchmark/src/node_benchmark.cc
@@ -23,7 +23,6 @@
 #include <array>
 #include <cstddef>
 #include <memory>
-#include <vector>
 
 #include "benchmark/benchmark.h"
 
@@ -54,7 +53,7 @@ BENCHMARK_F(NodeBenchmark, processPayloadBenchmark)(::benchmark::State& state) {
   for (auto _ : state) {
     node.processPayload(
         [](const std::size_t&, const std::size_t&) {
-          return std::vector<std::size_t>({0u, 1u, 2u, 3u, 4u, 5u, 6u, 7u});
+          return std::array<std::size_t, 8u>({0u, 1u, 2u, 3u, 4u, 5u, 6u, 7u});
         },
         [](const std::size_t&, const std::size_t&) { return 0u; }, 0u);
   }
@@ -78,7 +77,7 @@ BENCHMARK_F(NodeBenchmark, processChildsBenchmark)(::benchmark::State& state) {
   for (auto _ : state) {
     node.processChilds(
         [](const TestChildsArray&, const std::size_t&) {
-          return std::vector<std::size_t>({0u, 1u, 2u, 3u, 4u, 5u, 6u, 7u});
+          return std::array<std::size_t, 8u>({0u, 1u, 2u, 3u, 4u, 5u, 6u, 7u});
         },
         [](const std::size_t&, const std::size_t&) { return 0u; }, 0u);
   }

--- a/benchmark/src/tree_benchmark.cc
+++ b/benchmark/src/tree_benchmark.cc
@@ -28,7 +28,7 @@
 #include "tree.h"
 
 namespace october {
-namespace node {
+namespace tree {
 namespace benchmark {
 
 class TreeBenchmark : public ::benchmark::Fixture {};
@@ -90,7 +90,7 @@ BENCHMARK_F(TreeBenchmark, processNodesBenchmark)
 }
 
 }  // namespace benchmark
-}  // namespace node
+}  // namespace tree
 }  // namespace october
 
 BENCHMARK_MAIN();

--- a/include/tree.h
+++ b/include/tree.h
@@ -29,6 +29,7 @@
 #include <memory>
 #include <tuple>
 #include <utility>
+#include <vector>
 
 #include "node.h"
 
@@ -98,7 +99,7 @@ class Tree {
           const auto& target_childs = std::invoke(insert_func, shape, args...);
           std::for_each(
               target_childs.begin(), target_childs.end(),
-              [&childs](const auto& child_index) {
+              [&childs](const std::size_t& child_index) {
                 if (child_index < childs.size() && !childs.at(child_index)) {
                   childs.at(child_index) = std::make_unique<Node>(
                       Payload(), std::array<std::unique_ptr<Node>, N>());
@@ -106,7 +107,7 @@ class Tree {
               });
           return target_childs;
         },
-        [&shape_func](const auto& child_index, const Shape& shape,
+        [&shape_func](const std::size_t& child_index, const Shape& shape,
                       Args... args) {
           return std::tuple<Shape, Args&&...>(shape_func(child_index, shape),
                                               std::forward<Args>(args)...);
@@ -138,7 +139,7 @@ class Tree {
           auto target_childs = std::invoke(remove_func, shape, args...);
           std::for_each(
               target_childs.begin(), target_childs.end(),
-              [&childs](const auto& child_index) {
+              [&childs](const std::size_t& child_index) {
                 if (child_index < childs.size() && childs.at(child_index)) {
                   childs.at(child_index).reset();
                 }
@@ -151,7 +152,7 @@ class Tree {
                               std::inserter(res, res.begin()));
           return res;
         },
-        [&shape_func](const auto& child_index, const Shape& shape,
+        [&shape_func](const std::size_t& child_index, const Shape& shape,
                       Args... args) {
           return std::tuple<Shape, Args&&...>(shape_func(child_index, shape),
                                               std::forward<Args>(args)...);
@@ -177,7 +178,7 @@ class Tree {
   void processNodes(const ProcessFunc& process_func,
                     const ShapeFunc& shape_func, Args&&... args) {
     root_.processPayload(process_func,
-                         [&shape_func](const auto& child_index,
+                         [&shape_func](const std::size_t& child_index,
                                        const Shape& shape, Args... args) {
                            return std::tuple<Shape, Args&&...>(
                                shape_func(child_index, shape),


### PR DESCRIPTION
* Use `std::size_t` as index type in `Tree` implementation
* Use `std::array` instead of `std::vector` in node benchmark to increase performance
* Correct namespace name in tree benchmark